### PR TITLE
tables: print content of optional fields

### DIFF
--- a/cmd/ovsdb-mon/tables.go
+++ b/cmd/ovsdb-mon/tables.go
@@ -36,6 +36,9 @@ func (sp *StructPrinter) Append(objList interface{}) error {
 			if !field.IsValid() {
 				continue
 			}
+			if field.Type().Kind() == reflect.Ptr && !field.IsNil() {
+				field = field.Elem()
+			}
 			objData = append(objData, fmt.Sprintf("%v", field.Interface()))
 		}
 		data = append(data, objData)


### PR DESCRIPTION
Some fields are now optional in libovsdb, so they are represented as
pointers. On such cases, print their content and not just the pointer

Signed-off-by: Adrian Moreno <amorenoz@redhat.com>