### PR TITLE
Make table and column autocomplete case insensitive

### DIFF
--- a/cmd/ovsdb-mon/shell.go
+++ b/cmd/ovsdb-mon/shell.go
@@ -11,11 +11,11 @@ import (
 	"sync"
 	"time"
 
+	ishell "github.com/abiosoft/ishell/v2"
 	"github.com/kylelemons/godebug/diff"
 	"github.com/kylelemons/godebug/pretty"
 	"github.com/ovn-org/libovsdb/client"
 	"github.com/ovn-org/libovsdb/model"
-	ishell "gopkg.in/abiosoft/ishell.v2"
 )
 
 type eventType string

--- a/cmd/ovsdb-mon/tables.go
+++ b/cmd/ovsdb-mon/tables.go
@@ -63,8 +63,9 @@ func NewStructPrinter(writer io.Writer, stype reflect.Type, fieldSel ...string) 
 		for _, sel := range fieldSel {
 			found := false
 			for i := 0; i < stype.NumField(); i++ {
-				if stype.Field(i).Name == sel {
+				if strings.EqualFold(stype.Field(i).Name, sel) {
 					found = true
+					cols = append(cols, stype.Field(i).Name)
 					break
 				}
 			}
@@ -72,7 +73,6 @@ func NewStructPrinter(writer io.Writer, stype reflect.Type, fieldSel ...string) 
 				return nil, fmt.Errorf("Field %s not found in Type %s", sel, stype.Name())
 			}
 		}
-		cols = fieldSel
 	} else {
 		for i := 0; i < stype.NumField(); i++ {
 			field := stype.Field(i).Name

--- a/go.mod
+++ b/go.mod
@@ -3,15 +3,9 @@ module github.com/amorenoz/ovsdb-mon
 go 1.15
 
 require (
-	github.com/abiosoft/ishell v2.0.0+incompatible // indirect
-	github.com/abiosoft/readline v0.0.0-20180607040430-155bce2042db // indirect
-	github.com/chzyer/logex v1.1.10 // indirect
-	github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 // indirect
-	github.com/fatih/color v1.10.0 // indirect
-	github.com/flynn-archive/go-shlex v0.0.0-20150515145356-3f9db97f8568 // indirect
+	github.com/abiosoft/ishell/v2 v2.0.3-0.20210603102338-4f77a91e8ead
 	github.com/kylelemons/godebug v1.1.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/ovn-org/libovsdb v0.6.1-0.20210920174042-03e0010e3257
-	gopkg.in/abiosoft/ishell.v2 v2.0.0
 	k8s.io/apimachinery v0.22.2
 )

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb0
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
-github.com/abiosoft/ishell v2.0.0+incompatible h1:zpwIuEHc37EzrsIYah3cpevrIc8Oma7oZPxr03tlmmw=
-github.com/abiosoft/ishell v2.0.0+incompatible/go.mod h1:HQR9AqF2R3P4XXpMpI0NAzgHf/aS6+zVXRj14cVk9qg=
+github.com/abiosoft/ishell/v2 v2.0.3-0.20210603102338-4f77a91e8ead h1:OE1pGHs8LYY6Ny2Dt53i4geOEfOAGfx/AR8DySVD0Yw=
+github.com/abiosoft/ishell/v2 v2.0.3-0.20210603102338-4f77a91e8ead/go.mod h1:E4oTCXfo6QjoCart0QYa5m9w4S+deXs/P/9jA77A9Bs=
 github.com/abiosoft/readline v0.0.0-20180607040430-155bce2042db h1:CjPUSXOiYptLbTdr1RceuZgSFDQ7U15ITERUGrUORx8=
 github.com/abiosoft/readline v0.0.0-20180607040430-155bce2042db/go.mod h1:rB3B4rKii8V21ydCbIzH5hZiCQE7f5E9SzUb/ZZx530=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
@@ -42,8 +42,8 @@ github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v4.11.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
-github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=
-github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
+github.com/fatih/color v1.12.0 h1:mRhaKNwANqRgUBGKmnI5ZxEk7QXmjQeCcuYFMX2bfcc=
+github.com/fatih/color v1.12.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/flynn-archive/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BMXYYRWTLOJKlh+lOBt6nUQgXAfB7oVIQt5cNreqSLI=
 github.com/flynn-archive/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:rZfgFAXFS/z/lEd6LJmf9HVZ1LkgYiHx5pHhV5DR16M=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -246,8 +246,6 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-gopkg.in/abiosoft/ishell.v2 v2.0.0 h1:/J5yh3nWYSSGFjALcitTI9CLE0Tu27vBYHX0srotqOc=
-gopkg.in/abiosoft/ishell.v2 v2.0.0/go.mod h1:sFp+cGtH6o4s1FtpVPTMcHq2yue+c4DGOVohJCPUzwY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
This PR allows you to autocomplete even if you have started typing the name of the column or table in low case.

```
>>> list Logi <tab>
Logical_Router Logical_Switch
```
```
>>> list logi <tab>
logical_router logical_switch
```
```
>>> list logical_router N <tab>
Name Nat
```
```
>>> list logical_router n <tab>
name nat
```
```
>>> list logical_router nat <enter>
+----------------------+----------------------------------------+
|         NAME         |                  NAT                   |
+----------------------+----------------------------------------+
| GR_ovn-worker2       | [b504b2ba-fe7d-457c-8b23-48695e0aeda2] |
| GR_ovn-control-plane | [97558085-3fc9-4cf7-a1d2-66544b3be0d0] |
| GR_ovn-worker        | [305bf739-5dc7-408b-9d58-16b17641b8fc] |
| ovn_cluster_router   | []                                     |
+----------------------+----------------------------------------+
```

Fixes #24 