### PR TITLE
ovsdb-mon-ovn.yaml: use nodeAffinity to handle control-plane role

### DIFF
--- a/dist/ovsdb-mon-ovn.yaml
+++ b/dist/ovsdb-mon-ovn.yaml
@@ -36,5 +36,13 @@ spec:
   - key: node-role.kubernetes.io/master
     operator: Exists
   hostNetwork: true
-  nodeSelector:
-    node-role.kubernetes.io/master: ""
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: node-role.kubernetes.io/master
+            operator: Exists
+        - matchExpressions:
+          - key: node-role.kubernetes.io/control-plane
+            operator: Exists


### PR DESCRIPTION
ovsdb-mon-ovn uses a selector to only schedule its pod on the
node that is running OVN.

Starting on Kubernetes 1.24, master role has been renamed to
control-plane. Since nodeSelector does not support "logical or"
and we would like to keep ovsdb-mon backward compatible, this
change makes use of nodeAffinity to account for both.
        - node-role.kubernetes.io/master
        - node-role.kubernetes.io/control-plane

Signed-off-by: Flavio Fernandes <flaviof@redhat.com>