### PR TITLE
Security admission labels for namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ provide a ready to use binary for the K8 cluster.
     source ./ovsdb-mon-ovn.source
     source ./ovsdb-mon-ovs.source
 
+**Note:** Pod Security Admission must be taken into account when deploying ovsdb-mon,
+since it needs to access the host network. Being so, a namespace will be created
+with the required labels, and used by ovsdb-mon pod(s).
+For more info, see [the pod-security-admission documentation](https://kubernetes.io/docs/concepts/security/pod-security-admission/#pod-security-admission-labels-for-namespaces).
 
 ### Local machine (e.g: Openstack node)
 

--- a/dist/ovsdb-mon-ds.yaml
+++ b/dist/ovsdb-mon-ds.yaml
@@ -15,6 +15,8 @@ spec:
         - key: node-role.kubernetes.io/master
           operator: Exists
           effect: NoSchedule
+      securityContext:
+        runAsUser: 0
       containers:
         - name: ovsdb-mon
           image: quay.io/amorenoz/ovsdb-mon:latest

--- a/dist/ovsdb-mon-ovn.source
+++ b/dist/ovsdb-mon-ovn.source
@@ -4,16 +4,36 @@ then
     exit 1
 fi
 
-kubectl apply -f ./ovsdb-mon-ovn.yaml || { >&2 echo 'bad k8s?'; return; }
+kubectl create namespace ovsdb-mon --dry-run=client -o yaml | kubectl apply -f - 2>&1 | \
+    grep -v "kubectl.kubernetes.io/last-applied-configuration"
+kubectl label namespace ovsdb-mon --overwrite \
+    pod-security.kubernetes.io/enforce=privileged \
+    pod-security.kubernetes.io/audit=privileged \
+    pod-security.kubernetes.io/warn=privileged \
+    security.openshift.io/scc.podSecurityLabelSync=false
+until [[ $(kubectl get sa default -n ovsdb-mon -o=jsonpath='{.metadata.creationTimestamp}') ]]; do \
+    echo "waiting for service account for ovsdb-mon namespace to exist..."; sleep 3; done
+
+# If oc scc resource exists, configure role that allows ovsdb-mon to have priviledged access
+ocbin=$(which oc 2>/dev/null)
+[ -x "$ocbin" ] && scc=$($ocbin api-resources | grep securitycontextconstraints)
+if [ -n "$scc" ] ; then
+    $ocbin get rolebinding ovsdb-mon --no-headers -n ovsdb-mon 2>/dev/null || \
+    { $ocbin create role ovsdb-mon --verb=use --resource=scc --resource-name=privileged -n ovsdb-mon ;
+      $ocbin create rolebinding ovsdb-mon --role=ovsdb-mon --group=system:serviceaccounts:ovsdb-mon -n ovsdb-mon ; }
+fi
+
+kubectl apply -n ovsdb-mon -f ./ovsdb-mon-ovn.yaml || { >&2 echo 'bad k8s?'; return; }
 
 echo waiting for pod to become ready...
-kubectl wait --for=condition=ready pod/ovsdb-mon-ovn \
+kubectl wait -n ovsdb-mon --for=condition=ready pod/ovsdb-mon-ovn \
     --timeout=300s || { >&2 echo 'failed: error pod not ready' ; return; }
 
-alias ovsdb-mon.nb='kubectl exec -it ovsdb-mon-ovn -- ovsdb-mon.OVN_Northbound'
-alias ovsdb-mon.sb='kubectl exec -it ovsdb-mon-ovn -- ovsdb-mon.OVN_Southbound'
+alias ovsdb-mon.nb='kubectl exec -n ovsdb-mon -it ovsdb-mon-ovn -- ovsdb-mon.OVN_Northbound'
+alias ovsdb-mon.sb='kubectl exec -n ovsdb-mon -it ovsdb-mon-ovn -- ovsdb-mon.OVN_Southbound'
 
-echo 'to remove pod created, do: kubectl delete pod/ovsdb-mon-ovn'
+echo 'to remove pod created, do: kubectl delete -n ovsdb-mon pod/ovsdb-mon-ovn'
+echo 'to remove namespace created, do: kubectl delete -n ovsdb-mon ns/ovsdb-mon'
 echo 'commands to try:'
 echo '   ovsdb-mon.nb -auto -no-monitor nb_global,connection'
 echo '   ovsdb-mon.sb -auto -monitor Logical_Flow'

--- a/dist/ovsdb-mon-ovn.yaml
+++ b/dist/ovsdb-mon-ovn.yaml
@@ -3,6 +3,8 @@ kind: Pod
 metadata:
   name: ovsdb-mon-ovn
 spec:
+  securityContext:
+    runAsUser: 0
   containers:
   - name: ovsdb-mon-ovn
     image: quay.io/amorenoz/ovsdb-mon:latest

--- a/dist/ovsdb-mon-ovs.source
+++ b/dist/ovsdb-mon-ovs.source
@@ -4,12 +4,31 @@ then
     exit 1
 fi
 
-kubectl apply -f ./ovsdb-mon-ds.yaml || { >&2 echo 'bad k8s?'; return; }
+kubectl create namespace ovsdb-mon --dry-run=client -o yaml | kubectl apply -f - 2>&1 | \
+    grep -v "kubectl.kubernetes.io/last-applied-configuration"
+kubectl label namespace ovsdb-mon --overwrite \
+    pod-security.kubernetes.io/enforce=privileged \
+    pod-security.kubernetes.io/audit=privileged \
+    pod-security.kubernetes.io/warn=privileged \
+    security.openshift.io/scc.podSecurityLabelSync=false
+until [[ $(kubectl get sa default -n ovsdb-mon -o=jsonpath='{.metadata.creationTimestamp}') ]]; do \
+    echo "waiting for service account for ovsdb-mon namespace to exist..."; sleep 3; done
+
+# If oc scc resource exists, configure role that allows ovsdb-mon to have priviledged access
+ocbin=$(which oc 2>/dev/null)
+[ -x "$ocbin" ] && scc=$($ocbin api-resources | grep securitycontextconstraints)
+if [ -n "$scc" ] ; then
+    $ocbin get rolebinding ovsdb-mon --no-headers -n ovsdb-mon 2>/dev/null || \
+    { $ocbin create role ovsdb-mon --verb=use --resource=scc --resource-name=privileged -n ovsdb-mon ;
+      $ocbin create rolebinding ovsdb-mon --role=ovsdb-mon --group=system:serviceaccounts:ovsdb-mon -n ovsdb-mon ; }
+fi
+
+kubectl apply -n ovsdb-mon -f ./ovsdb-mon-ds.yaml || { >&2 echo 'bad k8s?'; return; }
 
 # create handy aliases for easy usage of ovsdb-mon.ovs
 DS='ovsdb-mon-ovs'
 POD_TUPLES=$(
-kubectl get pod  \
+kubectl get pod -n ovsdb-mon \
   -o jsonpath='{range .items[*]}{.spec.nodeName}{"/"}{.metadata.name}{" "}{end}' | grep ${DS} )
 
 set -y 2>/dev/null ||:  ; # this is for the zsh users out there
@@ -18,15 +37,15 @@ for POD_TUPLE in $POD_TUPLES ; do \
    NODE=$(echo $POD_TUPLE | cut -d/ -f1)
    POD=$(echo $POD_TUPLE | cut -d/ -f2)
    echo $NODE has pod ${POD} . Creating alias ovsdb-mon.ovs.$NODE
-   alias ovsdb-mon.ovs.$NODE="kubectl exec -it $POD -- ovsdb-mon.Open_vSwitch"
+   alias ovsdb-mon.ovs.$NODE="kubectl exec -n ovsdb-mon -it $POD -- ovsdb-mon.Open_vSwitch"
 done
 
 echo
-kubectl get ds ${DS}
+kubectl get ds -n ovsdb-mon ${DS}
 echo
-echo "to remove daemonset created, do: kubectl delete ds ${DS}"
+echo "to remove daemonset created, do: kubectl delete -n ovsdb-mon ds ${DS}"
 echo 'commands to try (after pod becomes ready):'
 echo "   ovsdb-mon.ovs.${NODE} list Interface Name Ofport ExternalIDs"
-echo "   kubectl exec -it ${POD} -- ovs-vsctl show"
-echo "   kubectl exec -it ${POD} -- ovs-ofctl --names dump-flows br-int table=0 | cut -d',' -f3-"
+echo "   kubectl exec -n ovsdb-mon -it ${POD} -- ovs-vsctl show"
+echo "   kubectl exec -n ovsdb-mon -it ${POD} -- ovs-ofctl --names dump-flows br-int table=0 | cut -d',' -f3-"
 echo


### PR DESCRIPTION
ovsdb-mon-ovn.source: Pay attention to securityContext

Pods created by ovsdb-mon need to use security admission labels
in order to be allowed in newer Kubernetes releases.

More info on these requirements is available at:
https://kubernetes.io/docs/concepts/security/pod-security-admission/#pod-security-admission-labels-for-namespaces

Closes: https://github.com/amorenoz/ovsdb-mon/issues/34